### PR TITLE
README.md: Removed prompt prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The bridge supports `--enable-ssh-support`, and has one additional requirement:
 - Exporting the necessary `SSH_AUTH_SOCK` is left up to the user, and it is not output like `ssh-agent -s` does.
 
   ```bash
-  export SSH_AUTH_SOCK=`$ gpgconf --list-dirs agent-ssh-socket`
+  export SSH_AUTH_SOCK=`gpgconf --list-dirs agent-ssh-socket`
   ```
 
 ## Caveats


### PR DESCRIPTION
In the explanation for enabling ssh-agent support, the sub-command of the command for setting SSH_AUTH_SOCK had the prefix of a default shell prompt "$". I fixed the sub-command by removing the invalid prefix.