### PR TITLE
gpgbridge.py: Fixed launching ssh agent proxy if path contains space

### DIFF
--- a/gpgbridge.py
+++ b/gpgbridge.py
@@ -373,7 +373,7 @@ def bridge_main(parsed_args):
         pageant_proxy_proc = subprocess.Popen(
             [
                 "powershell.exe", "-command", "python3.exe",
-                get_windows_script_location(), "--pageant-proxy"
+                '"' + get_windows_script_location() + '"', "--pageant-proxy"
             ] + (["--verbose"] if parsed_args.verbose else []),
             stdout=(None if parsed_args.verbose else subprocess.DEVNULL),
             stderr=(None if parsed_args.verbose else subprocess.DEVNULL))


### PR DESCRIPTION
Launching the script itself breaks if for example the Windows username contains a space.
This commit fixes it by adding quotion marks to the script path.